### PR TITLE
docs - rewrite long link

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -188,8 +188,8 @@
       </p>
       <p>
         We&apos;ve also started the process of defining an interface to Mastodon
-        so that following a hashtag on Mastodon taps into tags.pub; see
-        <a href="https://github.com/mastodon/fediverse_auxiliary_service_provider_specifications/issues/60">mastodon/fediverse_auxiliary_service_provider_specifications/issues/60</a> for discussions.
+        so that following a hashtag on Mastodon taps into tags.pub; 
+        <a href="https://github.com/mastodon/fediverse_auxiliary_service_provider_specifications/issues/60">see this discussion</a> for more.
       </p>
     </section>
     <section id="notifications">


### PR DESCRIPTION
This rewrites a long link that makes the entire page have horizontal scrollbars on mobile.