### PR TITLE
fix: support system color scheme (i.e. dark style)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,9 @@
   <title>tags.pub</title>
   <style>
     body {
+      color-scheme: light dark;
+      background: Canvas;
+      color: CanvasText;
       font-family: sans-serif;
       max-width: 65ch;
       margin: 2rem auto;


### PR DESCRIPTION
Minimal CSS fix to support CSS [color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme) and [system colors](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/system-color), e.g. for dark mode users.

- Defines explicit `color-scheme: light dark` support to allow the browser to use light or dark system colors depending on OS setting/user preference

- Uses `Canvas` and `CanvasText` named system colors for the background and foreground colors, to use browser defaults for both light and dark styles

Both are widely supported across browsers; plus, in the rare case of a browser not supporting it, it will fall back to the default colors (the same as today).

Screenshot from Firefox:

Light | Dark
----- | -----
![light](https://github.com/user-attachments/assets/ce2e8287-c7f1-45d5-9c95-11ec99b5a4e6) | ![dark](https://github.com/user-attachments/assets/aceab14d-93be-44e4-94ec-2ebe2fe968b7)