### PR TITLE
doc: Style/typography improvements

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,11 +10,43 @@
       color-scheme: light dark;
       background: Canvas;
       color: CanvasText;
-      font-family: sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, Adwaita Sans, Cantarell, Ubuntu, roboto, noto, helvetica, arial, sans-serif;
+      font-size: 110%;
+      line-height: 1.67;
       max-width: 65ch;
       margin: 2rem auto;
       padding: 0 1rem;
       text-align: left;
+    }
+
+    h1 {
+      font-size: 3.5em;
+      font-weight: 400;
+      letter-spacing: -0.05em;
+      margin-block-start: 1.25em;
+    }
+
+    h1 + p {
+      font-size: 1.25em;
+      margin-block-end: 3em;
+    }
+
+    h2 {
+      font-weight: 500;
+      margin-block: 3em 0.5em;
+    }
+
+    h3 {
+      opacity: 0.67;
+      margin-block: 2.5em 0.75em;
+    }
+
+    h2 + section h3 {
+      margin-block-start: 0;
+    }
+
+    p {
+      margin-block: 0 1.33em;
     }
   </style>
 </head>

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,9 @@
   <title>tags.pub</title>
   <style>
     body {
+      color-scheme: light dark;
+      background: Canvas;
+      color: CanvasText;
       font-family: sans-serif;
       max-width: 65ch;
       margin: 2rem auto;


### PR DESCRIPTION
Builds on #57 to improve the landing page design a bit:

- Use a native font stack for familiar default fonts
- Increase line-height for legibility
- Style headings inspired a bit by SWF site
- Increase margins for improved whitespace

Continues to work in light and dark styles like #57.

## Before

Light | Dark
----- | -----
<img width="2546" height="6633" alt="Screenshot 2026-08-07 at 12-14-43 tags pub" src="https://github.com/user-attachments/assets/981be0e9-9601-4f4c-a214-b93bcf88d39b" /> | <img width="2546" height="6633" alt="Screenshot 2026-08-07 at 12-14-30 tags pub" src="https://github.com/user-attachments/assets/256bae4e-ebcd-4e55-92e0-8df48f987c9d" />

## After

Light | Dark
----- | -----
<img width="2546" height="10206" alt="Screenshot 2026-08-07 at 12-13-40 tags pub" src="https://github.com/user-attachments/assets/e55d9136-015c-436d-bde1-c792db94d42d" /> | <img width="2546" height="10206" alt="Screenshot 2026-08-07 at 12-13-48 tags pub" src="https://github.com/user-attachments/assets/792c6ffd-fd1e-4902-84dd-396854a1a7d5" />